### PR TITLE
Expose ASIC share candidates in the info log

### DIFF
--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -59,8 +59,8 @@ void ASIC_result_task(void *pvParameters)
             asic_result->nonce,
             asic_result->rolled_version);
 
-        //log the ASIC response
-        ESP_LOGD(TAG, "Ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %.2f.", asic_result->rolled_version, asic_result->nonce, nonce_diff, GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->pool_diff);
+        // Keep share candidates visible through the standard log stream.
+        ESP_LOGI(TAG, "Ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %.2f.", asic_result->rolled_version, asic_result->nonce, nonce_diff, GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->pool_diff);
 
         if (nonce_diff >= GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->pool_diff)
         {


### PR DESCRIPTION
Promote the existing nonce difficulty line from debug to info so standard log consumers can observe candidate shares and the active pool target.